### PR TITLE
Allowing link_names to be an int

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ and then calling the script of your choice. As an example, to execute posting a 
     export SLACK_TOKEN=REDACTED
     export TEST_SLACK_CHANNEL=REDACTED
     echo '[{ "title": "test attachment 1", "text": "test attachment 1 text" }]' > msg_attachments.json
-    echo "{\"source\": { \"token\" :\"${SLACK_TOKEN}\", \"method\": \"chat.postMessage\" }, \"params\": { \"attachments_file\": \"msg_attachments.json\", \"channel\" : \"${TEST_SLACK_CHANNEL}\", \"icon_url\": \"http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png\", \"username\": \"concourse\", \"link_names\": \"1\"}}" | ./out .
+    echo "{\"source\": { \"token\" :\"${SLACK_TOKEN}\", \"method\": \"chat.postMessage\" }, \"params\": { \"attachments_file\": \"msg_attachments.json\", \"channel\" : \"${TEST_SLACK_CHANNEL}\", \"icon_url\": \"http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png\", \"username\": \"concourse\", \"link_names\": 1}}" | ./out .
 
 ### Publishing to public docker registry
 

--- a/assets/common/common.go
+++ b/assets/common/common.go
@@ -98,8 +98,8 @@ func ValidateAndBuildPostBodyPostMessage(input ConcourseInput) (url.Values, erro
 	data.Set("attachments", attachmentString)
 	data.Set("token", input.Source.Token)
 	data.Set("channel", input.Params.Channel)
+	data.Set("link_names", strconv.Itoa(input.Params.LinkNames))
 
-	if input.Params.LinkNames != "" { data.Set("link_names", input.Params.LinkNames) }
 	if input.Params.IconUrl != "" { data.Set("icon_url", input.Params.IconUrl) }
 	if input.Params.Username != "" { data.Set("username", input.Params.Username) }
 

--- a/assets/common/models.go
+++ b/assets/common/models.go
@@ -18,7 +18,7 @@ type ConcourseParams struct {
 	Attachments     string `json:"attachments"`
 	IconUrl         string `json:"icon_url"`
 	Username        string `json:"username"`
-	LinkNames       string `json:"link_names"`
+	LinkNames       int    `json:"link_names"`
 }
 
 type ConcourseInput struct {


### PR DESCRIPTION
I was under the impression that when the yaml of the pipeline was parsed the integer would be seen as a string, however it is seen as an integer.  This allows for that to be specified as an integer in the pipeline yaml.