### PR TITLE
fixing a bug where supplying just a title does not result in a messag…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS build
 
-RUN apk update && apk --no-cache add bash ca-certificates && apk add --no-cache gcc musl-dev
+RUN apk update && apk --no-cache add gcc musl-dev
 
 COPY assets /assets
 
@@ -16,6 +16,8 @@ RUN cd /assets/common && \
 
 
 FROM alpine:edge AS resource
+
+RUN apk update && apk --no-cache add bash ca-certificates
 
 COPY --from=build /assets/check /opt/resource/check
 COPY --from=build /assets/in /opt/resource/in

--- a/assets/common/common.go
+++ b/assets/common/common.go
@@ -99,7 +99,7 @@ func ValidateAndBuildPostBodyPostMessage(input ConcourseInput) (data url.Values,
 		if len(attachments) != 0 {
 			hasText := false
 			for _, a := range attachments {
-				if len(a.Text) != 0 {
+				if (len(a.Text) != 0) || (len(a.Title) != 0) {
 					hasText = true
 				}
 			}
@@ -107,12 +107,6 @@ func ValidateAndBuildPostBodyPostMessage(input ConcourseInput) (data url.Values,
 				return data, err, true
 			}
 		}
-	}
-	switch "" {
-	case input.Source.Token:
-		return nil, errors.New(fmt.Sprintf("Token is a required param")), false
-	case input.Params.Channel:
-		return nil, errors.New(fmt.Sprintf("Channel is a required param")), false
 	}
 
 	data.Set("attachments", attachmentString)

--- a/assets/common/common_test.go
+++ b/assets/common/common_test.go
@@ -90,9 +90,10 @@ func TestMessage(t *testing.T) {
 		t.Errorf("Unexpected error %s", err.Error())
 	}
 	if len(data.Get("attachments")) == 0 {
-		t.Errorf("Expected attahments to exist")
+		t.Errorf("Expected attachments to exist")
 	}
 }
+
 func TestEmptyMessage(t *testing.T) {
 	input := common.ConcourseInput{}
 	input.Source.Method = "chat.postMessage"
@@ -105,7 +106,22 @@ func TestEmptyMessage(t *testing.T) {
 		t.Errorf("Unexpected error %s", err.Error())
 	}
 	if !empty {
-		t.Error("ValidateAndBuildPostBody didnt return an empty message of true when sent an emtpy message")
+		t.Error("ValidateAndBuildPostBody did not return an empty message of true when sent an empty message")
+	}
+}
+func TestJustTitle(t *testing.T) {
+	input := common.ConcourseInput{}
+	input.Source.Method = "chat.postMessage"
+	input.Params.AttachmentsFile = "just_title.json"
+	input.Source.Token = "validToken"
+	input.Params.Channel = "mychannel1"
+	_, _, err, empty := common.ValidateAndBuildPostBody(input)
+
+	if err != nil {
+		t.Errorf("Unexpected error %s", err.Error())
+	}
+	if empty {
+		t.Error("ValidateAndBuildPostBody returned empty when there was a title")
 	}
 }
 func TestValidateAndBuildBody_InvalidMethod(t *testing.T) {

--- a/assets/common/common_test.go
+++ b/assets/common/common_test.go
@@ -94,7 +94,7 @@ func TestMessage(t *testing.T) {
 	}
 }
 
-func TestEmptyMessage(t *testing.T) {
+func TestJustText(t *testing.T) {
 	input := common.ConcourseInput{}
 	input.Source.Method = "chat.postMessage"
 	input.Params.AttachmentsFile = "empty.json"

--- a/assets/common/models.go
+++ b/assets/common/models.go
@@ -28,7 +28,8 @@ type ConcourseInput struct {
 }
 
 type Attachment struct {
-	Text string `json:"text"`
+	Text  string `json:"text"`
+	Title string `json:"title"`
 }
 
 type ConcourseVersion struct {


### PR DESCRIPTION
…e.   text is actually not required, so check for existence of title OR text when detecting a noop